### PR TITLE
fix a deadlock when emitting more than one message

### DIFF
--- a/src/kakadu.h
+++ b/src/kakadu.h
@@ -70,7 +70,6 @@ public:
 	flush(bool end_of_message)
 	{
 		if (end_of_message) {
-
 			vips_error("VipsForeignKakadu", "%s", 
 				std::accumulate(strings.begin(), 
 					            strings.end(), 
@@ -81,6 +80,8 @@ public:
 			// kdu_exception (an int)
 			throw -1;
 		}
+
+		kdu_thread_safe_message::flush(end_of_message);
 	}
 
 private:
@@ -104,6 +105,8 @@ public:
 							                std::string("")).c_str());
 			strings.clear();
 		}
+
+		kdu_thread_safe_message::flush(end_of_message);
 	}
 
 private:


### PR DESCRIPTION
We were not chaining up in flush(), so the message mutex was never being released.

See https://github.com/harvard-lts/kakadu-vips/issues/21

Thanks @quoideneuf